### PR TITLE
Week4 [STEP 2] Gundy

### DIFF
--- a/BodyCondition.swift
+++ b/BodyCondition.swift
@@ -66,6 +66,10 @@ class BodyCondition {
     }
     
     func doRoutine(_ routine: Routine) {
+        if self.fatigue >= 100 {
+            print("\(self.name)은(는) 너무 피곤해서 \(routine.name)을(를) 할 수 없다.")
+            return
+        }
         if routine.activities.isEmpty == false {
             print("\(routine.name) 루틴을 몇 번 반복할까요?")
             continueRoutine(routine)
@@ -74,6 +78,7 @@ class BodyCondition {
                 try routine.startRoutine(person: self)
             } catch RoutineError.noRoutine {
                 print("\(routine.name) 루틴은 아무 활동도 없습니다.")
+                print("설명: \(RoutineError.noRoutine.localizedDescription)\n")
             } catch {
                 print(error)
             }
@@ -85,9 +90,11 @@ class BodyCondition {
             try routine.startRoutine(person: self)
         } catch RoutineError.wrongInput {
             print("잘못된 입력 형식입니다. 다시 입력해주세요.")
+            print("설명: \(RoutineError.wrongInput.localizedDescription)\n")
             continueRoutine(routine)
         } catch RoutineError.fatigueAccumulation {
             print("피로도가 100 이상입니다. 루틴을 중단합니다.")
+            print("설명: \(RoutineError.fatigueAccumulation.localizedDescription)\n")
             checkBodyCondition()
         } catch {
             print(error)

--- a/BodyCondition.swift
+++ b/BodyCondition.swift
@@ -27,6 +27,7 @@ class BodyCondition {
     var fatigue: Int = 0 {
         didSet {
             self.printChangeInCondition(property: "피로도가", amountOfChange: (fatigue - oldValue))
+            print("--------------")
         }
     }
     
@@ -41,7 +42,6 @@ class BodyCondition {
         } else {
             print("\(self.name)은(는) 너무 피곤해서 \(activity.name)을(를) 할 수 없다.")
         }
-        checkBodyCondition()
     }
     
     private func printChangeInCondition(property: String, amountOfChange: Int) {
@@ -55,7 +55,6 @@ class BodyCondition {
     func checkBodyCondition() {
         print(
         """
-        --------------
         현재 \(self.name)의 컨디션은 다음과 같습니다.
         상체근력: \(self.upperBodyStrength)
         하체근력: \(self.lowerBodyStrength)
@@ -64,5 +63,34 @@ class BodyCondition {
         --------------
         """
         )
+    }
+    
+    func doRoutine(_ routine: Routine) {
+        if routine.activities.isEmpty == false {
+            print("\(routine.name) 루틴을 몇 번 반복할까요?")
+            continueRoutine(routine)
+        } else {
+            do {
+                try routine.startRoutine(person: self)
+            } catch RoutineError.noRoutine {
+                print("\(routine.name) 루틴은 아무 활동도 없습니다.")
+            } catch {
+                print(error)
+            }
+        }
+    }
+    
+    private func continueRoutine(_ routine: Routine) {
+        do {
+            try routine.startRoutine(person: self)
+        } catch RoutineError.wrongInput {
+            print("잘못된 입력 형식입니다. 다시 입력해주세요.")
+            continueRoutine(routine)
+        } catch RoutineError.fatigueAccumulation {
+            print("피로도가 100 이상입니다. 루틴을 중단합니다.")
+            checkBodyCondition()
+        } catch {
+            print(error)
+        }
     }
 }

--- a/CodeStarterCamp_Week4.xcodeproj/project.pbxproj
+++ b/CodeStarterCamp_Week4.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		34811DE8274B93FB00A1E994 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34811DE7274B93FB00A1E994 /* main.swift */; };
 		BF827EE22886A451000A8F54 /* BodyCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF827EE12886A451000A8F54 /* BodyCondition.swift */; };
 		BF827EE42886A492000A8F54 /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF827EE32886A491000A8F54 /* Activity.swift */; };
+		BF827EEC2887D659000A8F54 /* Routine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF827EEB2887D659000A8F54 /* Routine.swift */; };
+		BF827EF02887DEF0000A8F54 /* RoutineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF827EEF2887DEF0000A8F54 /* RoutineError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +31,8 @@
 		34811DE7274B93FB00A1E994 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		BF827EE12886A451000A8F54 /* BodyCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyCondition.swift; sourceTree = "<group>"; };
 		BF827EE32886A491000A8F54 /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
+		BF827EEB2887D659000A8F54 /* Routine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routine.swift; sourceTree = "<group>"; };
+		BF827EEF2887DEF0000A8F54 /* RoutineError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -47,6 +51,8 @@
 			children = (
 				BF827EE32886A491000A8F54 /* Activity.swift */,
 				BF827EE12886A451000A8F54 /* BodyCondition.swift */,
+				BF827EEB2887D659000A8F54 /* Routine.swift */,
+				BF827EEF2887DEF0000A8F54 /* RoutineError.swift */,
 				34811DE6274B93FB00A1E994 /* CodeStarterCamp_Week4 */,
 				34811DE5274B93FB00A1E994 /* Products */,
 			);
@@ -125,8 +131,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF827EF02887DEF0000A8F54 /* RoutineError.swift in Sources */,
 				BF827EE42886A492000A8F54 /* Activity.swift in Sources */,
 				34811DE8274B93FB00A1E994 /* main.swift in Sources */,
+				BF827EEC2887D659000A8F54 /* Routine.swift in Sources */,
 				BF827EE22886A451000A8F54 /* BodyCondition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CodeStarterCamp_Week4/main.swift
+++ b/CodeStarterCamp_Week4/main.swift
@@ -27,13 +27,17 @@ let longDistanceRunning: Activity = .init(name: "오래달리기", action: {
     longDistanceRunning.changeFatigue(condition: $0, min: 20, max: 30)
 })
 
+let doubleJump: Activity = .init(name: "더블 점프", action: {
+    doubleJump.lowerGrowth(condition: $0, min: 10, max: 20)
+    doubleJump.changeFatigue(condition: $0, min: 1, max: 20)
+})
+
 let activeRest: Activity = .init(name: "동적휴식", action: {
     activeRest.changeFatigue(condition: $0, min: 5, max: 10, rest: true)
 })
 
-gundy.doActivity(sitUp)
-gundy.doActivity(squat)
-gundy.doActivity(longDistanceRunning)
-gundy.doActivity(activeRest)
-gundy.fatigue = 100
-gundy.doActivity(sitUp)
+var crossFit: Routine = .init(name: "크로스핏", activities: [doubleJump, sitUp])
+var tabata: Routine = .init(name: "타바타", activities: [])
+
+gundy.doRoutine(crossFit)
+gundy.doRoutine(tabata)

--- a/CodeStarterCamp_Week4/main.swift
+++ b/CodeStarterCamp_Week4/main.swift
@@ -39,5 +39,5 @@ let activeRest: Activity = .init(name: "동적휴식", action: {
 var crossFit: Routine = .init(name: "크로스핏", activities: [doubleJump, sitUp])
 var tabata: Routine = .init(name: "타바타", activities: [])
 
-gundy.doRoutine(crossFit)
 gundy.doRoutine(tabata)
+gundy.doRoutine(crossFit)

--- a/Routine.swift
+++ b/Routine.swift
@@ -1,0 +1,55 @@
+//
+//  Routine.swift
+//  CodeStarterCamp_Week4
+//
+//  Created by 이준영 on 2022/07/20.
+//
+
+import Foundation
+
+class Routine {
+    var name: String
+    var activities: Array<Activity>
+    
+    init(name: String, activities: Array<Activity>) {
+        self.name = name
+        self.activities = activities
+    }
+    
+    func startRoutine(person: BodyCondition) throws -> Void{
+        guard activities.isEmpty == false else {
+            throw RoutineError.noRoutine
+        }
+        while let input = readLine() {
+            guard let sets = Int(input) else {
+                throw RoutineError.wrongInput
+            }
+            print("--------------")
+            for set in 1...sets {
+                print("\(translator(number: set)) 번째 \(self.name)을(를) 시작합니다.")
+                for member in 0...(self.activities.count - 1) {
+                    person.doActivity(self.activities[member])
+                    guard person.fatigue <= 100 else {
+                        throw RoutineError.fatigueAccumulation
+                    }
+                }
+            }
+            person.checkBodyCondition()
+            break
+        }
+    }
+}
+
+func translator(number: Int) -> String {
+    switch number {
+    case 1:
+        return "첫"
+    case 2:
+        return "두"
+    case 3:
+        return "세"
+    default:
+        return "\(number)"
+    }
+}
+

--- a/Routine.swift
+++ b/Routine.swift
@@ -16,12 +16,15 @@ class Routine {
         self.activities = activities
     }
     
-    func startRoutine(person: BodyCondition) throws -> Void{
+    func startRoutine(person: BodyCondition) throws -> Void {
         guard activities.isEmpty == false else {
             throw RoutineError.noRoutine
         }
         while let input = readLine() {
             guard let sets = Int(input) else {
+                throw RoutineError.wrongInput
+            }
+            guard sets > 0 else {
                 throw RoutineError.wrongInput
             }
             print("--------------")

--- a/RoutineError.swift
+++ b/RoutineError.swift
@@ -12,3 +12,16 @@ enum RoutineError: Error {
     case fatigueAccumulation
     case noRoutine
 }
+
+extension RoutineError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .wrongInput:
+            return "잘못된 입력 형식입니다. 바른 형식을 입력해야 합니다."
+        case .noRoutine:
+            return "아무 활동도 없는 루틴입니다."
+        case .fatigueAccumulation:
+            return "피로도가 100 이상입니다. 루틴을 수행할 수 없는 상태입니다."
+        }
+    }
+}

--- a/RoutineError.swift
+++ b/RoutineError.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  CodeStarterCamp_Week4
+//
+//  Created by 이준영 on 2022/07/20.
+//
+
+import Foundation
+
+enum RoutineError: Error {
+    case wrongInput
+    case fatigueAccumulation
+    case noRoutine
+}


### PR DESCRIPTION
@eunseo5355 
헤일리! 이번 스텝은 만족스럽게 진행한거같아요!
매번 좋은 피드백을 해주셔서 이번에 이렇게 만족스럽게 한 것 같은데,
그치만 원래 만족스러울 수록 잘못한 부분이 있더라도 눈에 띄지 않는 법이니까
호된 코멘트 미리 감사합니다! 😄

## 고민했던 점
 ### 오류 패턴
 - 제시된 에러 외에도 어떤 에러가 있을지 고민해보았고, 루틴을 구성할 때 아직 내용을 구성하지 못해 빈 루틴이 있을 수 있다고 생각했습니다. 그래서 빈 루틴의 에러인 noRoutine을 추가했습니다.
 - 잘못된 입력이 있을시 입력을 다시 받는 wrongInput 오류의 경우 코드의 길이를 짧게 하려면 루틴의 메소드인 startRoutine 내에서 안내문구를 출력하고 continue를 사용하는 것이 합리적이었으나, do-catch를 이용해 에러처리를 하는 것으로 한정된 과제였기 때문에 그리하지 못했습니다. 그나마 중복 코드를 줄이고자 BodyCondition의 메소드 continueRoutine를 추가해 사용하였습니다.
 ### 입력값에 따른 루틴 횟수 출력
- 숫자를 한 번째, 두 번째 처럼 한글로 바꾸는 것을 과연 몇회까지 해야 적절한 것인가 고민했습니다. 현실에서는 한 루틴내에 이미 운동이 반복적으로 사용되고 전체 루틴을 반복하는 케이스가 적기 때문입니다.
- 보통 루틴은 3회 이내에 끝난다고 생각해 "세 번째"까지만 번역을 실행하였고, 차후 case를 더 늘리더라도 코드의 수정없이 자동으로 반영되게 translator 메소드를 정의하였습니다.
- 비교적 반복적으로 루틴을 수행하는 대표적인 운동인 크로스핏과 타바타를 인스턴스로 생성했습니다.
- 만약 Activity의 프로퍼티인 action의 매개변수로 횟수나 시간등을 (기본 값과 함께) 추가한다면 루틴을 더욱 현실적으로 구성할 수 있겠다고 생각했습니다.

 ---


 ## 조언을 얻고 싶은 부분
 ### 피로도 관련
 - 현재는 피로도가 100이상일 때 루틴을 시도하면 루틴이 시작되고 Activity의 action을 실패하며 루틴을 종료하게 설정했는데요, 혹시 헤일리는 피로도가 100이상이면 루틴 시작도 못하게 (가령 현재의 빈 루틴을 실행했을 때 처럼) 막는게 더 낫다고 생각하시나요?